### PR TITLE
docs: Update HACS installation and prepare v2.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,19 @@ A modern Home Assistant custom integration for Oura Ring using the v2 API with O
 
 ### HACS Installation (Recommended)
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=louispires&repository=oura-v2-custom-component&category=integration)
-
-**Click the button above** to add this repository to HACS, or follow these manual steps:
+**Oura Ring is now available in the HACS default repository!**
 
 1. Open HACS in your Home Assistant instance
 2. Click on "Integrations"
-3. Click the three dots in the top right corner
-4. Select "Custom repositories"
-5. Add this repository URL: `https://github.com/louispires/oura-v2-custom-component`
-6. Select category: "Integration"
-7. Click "Add"
-8. Find "Oura Ring" in the integration list and click "Download"
-9. Restart Home Assistant
+3. Search for "Oura Ring"
+4. Click "Download"
+5. Restart Home Assistant
+
+### Add Integration to Home Assistant
+
+[![Open your Home Assistant instance and start the Oura Ring integration setup.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=oura)
+
+**Click the button above** to add the Oura Ring integration to your Home Assistant instance.
 
 ### Manual Installation
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,4 +1,45 @@
-﻿## 🐛 Oura Ring v2 Integration v2.0.1 - Network Resilience
+﻿## 🎉 Oura Ring v2 Integration v2.1.0 - Feature Release
+
+This feature release adds a new diagnostic sensor and improves documentation for easier installation!
+
+## ✨ NEW FEATURES
+
+### Low Battery Alert Sensor
+- **New Sensor**: `low_battery_alert` diagnostic sensor
+- **Data Source**: Extracted from Oura sleep data endpoint
+- **Type**: Boolean sensor indicating if battery was low during sleep
+- **Category**: Diagnostic (hidden from main UI by default)
+- **Icon**: `mdi:battery-alert`
+- **Default Value**: False when not present in API response
+- **Use Cases**: 
+  - Track ring battery alerts during sleep sessions
+  - Create automations for low battery notifications
+  - Better understand data quality issues related to battery level
+
+### Documentation Improvements
+- **HACS Default Repository**: Updated installation instructions to reflect that Oura Ring is now in HACS default repository
+- **Simplified Installation**: Removed custom repository instructions - now just search for "Oura Ring" in HACS
+- **Add Integration Button**: Added my.home-assistant.io badge for one-click integration setup
+- **Better User Experience**: Streamlined installation process for new users
+
+## 🧪 TESTING & VALIDATION
+
+- ✅ All 43 automated tests passing (4 new tests added)
+- ✅ Hassfest validation: 0 invalid integrations  
+- ✅ HACS compliance verified
+- ✅ Docker-based testing with Home Assistant 2025.11
+- ✅ New sensor extraction logic tested with True/False/missing values
+- ✅ Boolean sensor entity tests added
+
+## 📊 SENSOR COUNT UPDATE
+
+- **Previous version**: 43 sensors
+- **This version**: 44 sensors (+1 new diagnostic sensor)
+- **Total Sleep Sensors**: 14 (added Low Battery Alert)
+
+---
+
+## 🐛 Oura Ring v2 Integration v2.0.1 - Network Resilience
 
 This bugfix release improves integration resilience to transient network issues.
 


### PR DESCRIPTION
## Documentation Updates

This PR updates the README to reflect that Oura Ring is now available in the HACS default repository and prepares the v2.1.0 release notes.

## Changes

### README Updates
- **HACS Default Repository**: Updated installation instructions - users can now simply search for 'Oura Ring' in HACS
- **Simplified Process**: Removed custom repository instructions (no longer needed)
- **Add Integration Button**: Added my.home-assistant.io badge for one-click integration setup
- **Better UX**: Streamlined installation experience for new users

### Release Notes
- **v2.1.0 Release Notes**: Added comprehensive release notes for the new low battery alert sensor feature
- **Feature Documentation**: Documented the new diagnostic sensor and its use cases
- **Test Coverage**: Noted 4 new tests and 44 total sensors

## Benefits
-  Easier installation for new users
-  One-click integration setup button
-  Clear documentation of HACS default availability
-  Ready for v2.1.0 release

## Testing
-  Badge links verified
-  Markdown formatting checked
-  Release notes comprehensive