### PR TITLE
Fix timezone off-by-one and statistics chart rendering

### DIFF
--- a/custom_components/oura/api.py
+++ b/custom_components/oura/api.py
@@ -5,6 +5,7 @@ import asyncio
 from datetime import datetime, timedelta
 import logging
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from aiohttp import ClientSession, ClientResponseError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -40,8 +41,10 @@ class OuraApiClient:
         Args:
             days_back: Number of days of historical data to fetch (default: 1)
         """
-        end_date = datetime.now().date()
-        start_date = end_date - timedelta(days=days_back)
+        local_tz = ZoneInfo(self.hass.config.time_zone)
+        today = datetime.now(tz=local_tz).date()
+        end_date = today + timedelta(days=1)  # Oura API end_date is exclusive
+        start_date = today - timedelta(days=days_back)
 
         sleep_data, readiness_data, activity_data, heartrate_data, sleep_detail_data, stress_data, resilience_data, spo2_data, vo2_max_data, cardiovascular_age_data, sleep_time_data = await asyncio.gather(
             self._async_get_sleep(start_date, end_date),

--- a/custom_components/oura/statistics.py
+++ b/custom_components/oura/statistics.py
@@ -60,13 +60,13 @@ STATISTICS_METADATA = {
     "sleep_efficiency": {"name": "Sleep Efficiency", "unit": "%", "has_mean": True, "has_sum": False},
     "restfulness": {"name": "Restfulness", "unit": "%", "has_mean": True, "has_sum": False},
     "sleep_timing": {"name": "Sleep Timing", "unit": None, "has_mean": True, "has_sum": False},
-    "total_sleep_duration": {"name": "Total Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
-    "deep_sleep_duration": {"name": "Deep Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
-    "rem_sleep_duration": {"name": "REM Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
-    "light_sleep_duration": {"name": "Light Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
-    "awake_time": {"name": "Awake Time", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
+    "total_sleep_duration": {"name": "Total Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
+    "deep_sleep_duration": {"name": "Deep Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
+    "rem_sleep_duration": {"name": "REM Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
+    "light_sleep_duration": {"name": "Light Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
+    "awake_time": {"name": "Awake Time", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
     "sleep_latency": {"name": "Sleep Latency", "unit": UnitOfTime.MINUTES, "has_mean": True, "has_sum": False},
-    "time_in_bed": {"name": "Time in Bed", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
+    "time_in_bed": {"name": "Time in Bed", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
     "bedtime_start": {"name": "Bedtime Start", "unit": None, "has_mean": False, "has_sum": False},
     "bedtime_end": {"name": "Bedtime End", "unit": None, "has_mean": False, "has_sum": False},
     "deep_sleep_percentage": {"name": "Deep Sleep Percentage", "unit": "%", "has_mean": True, "has_sum": False},
@@ -89,8 +89,8 @@ STATISTICS_METADATA = {
     "average_heart_rate": {"name": "Average Heart Rate", "unit": "bpm", "has_mean": True, "has_sum": False},
     "min_heart_rate": {"name": "Minimum Heart Rate", "unit": "bpm", "has_mean": True, "has_sum": False},
     "max_heart_rate": {"name": "Maximum Heart Rate", "unit": "bpm", "has_mean": True, "has_sum": False},
-    "stress_high_duration": {"name": "Stress High Duration", "unit": UnitOfTime.MINUTES, "has_mean": True, "has_sum": False},
-    "recovery_high_duration": {"name": "Recovery High Duration", "unit": UnitOfTime.MINUTES, "has_mean": True, "has_sum": False},
+    "stress_high_duration": {"name": "Stress High Duration", "unit": UnitOfTime.MINUTES, "has_mean": False, "has_sum": True},
+    "recovery_high_duration": {"name": "Recovery High Duration", "unit": UnitOfTime.MINUTES, "has_mean": False, "has_sum": True},
     "stress_day_summary": {"name": "Stress Day Summary", "unit": None, "has_mean": False, "has_sum": False},
     "resilience_level": {"name": "Resilience Level", "unit": None, "has_mean": False, "has_sum": False},
     "sleep_recovery_score": {"name": "Sleep Recovery Score", "unit": None, "has_mean": True, "has_sum": False},
@@ -431,11 +431,17 @@ async def _create_statistic(
 
     # Create data points
     statistics = []
-    for point in data_points:
+    sorted_data_points = sorted(data_points, key=lambda point: point["timestamp"])
+    running_sum = 0.0
+    for point in sorted_data_points:
+        value = point["value"]
+        if metadata["has_sum"]:
+            running_sum += value
         stat_data = StatisticData(
             start=point["timestamp"],
-            mean=point["value"] if metadata["has_mean"] else None,
-            sum=point["value"] if metadata["has_sum"] else None,
+            state=value if metadata["has_sum"] else None,
+            mean=value if metadata["has_mean"] else None,
+            sum=running_sum if metadata["has_sum"] else None,
         )
         statistics.append(stat_data)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,53 @@
+"""Tests for Oura API client date window handling."""
+from datetime import date, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.oura.api import OuraApiClient
+
+
+class _FrozenDateTime(datetime):
+    """Frozen datetime for deterministic timezone-aware date calculations."""
+
+    @classmethod
+    def now(cls, tz=None):
+        """Return a fixed local time and require timezone-aware calls."""
+        assert tz is not None
+        return cls(2026, 3, 23, 1, 30, tzinfo=tz)
+
+
+@pytest.mark.asyncio
+async def test_async_get_data_uses_local_date_and_exclusive_end_date():
+    """Test timezone-aware date range and +1 day exclusive end date handling."""
+    hass = MagicMock()
+    hass.config.time_zone = "America/Denver"
+    session = MagicMock()
+    entry = MagicMock()
+    client = OuraApiClient(hass, session, entry)
+
+    endpoint_methods = [
+        "_async_get_sleep",
+        "_async_get_readiness",
+        "_async_get_activity",
+        "_async_get_heartrate",
+        "_async_get_sleep_detail",
+        "_async_get_stress",
+        "_async_get_resilience",
+        "_async_get_spo2",
+        "_async_get_vo2_max",
+        "_async_get_cardiovascular_age",
+        "_async_get_sleep_time",
+    ]
+    for method_name in endpoint_methods:
+        setattr(client, method_name, AsyncMock(return_value={"data": []}))
+
+    with patch("custom_components.oura.api.datetime", _FrozenDateTime):
+        await client.async_get_data(days_back=1)
+
+    expected_start = date(2026, 3, 22)
+    expected_end = date(2026, 3, 24)
+    for method_name in endpoint_methods:
+        mocked_method = getattr(client, method_name)
+        assert mocked_method.await_count == 1
+        assert mocked_method.await_args.args == (expected_start, expected_end)

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -8,6 +8,7 @@ from custom_components.oura.statistics import (
     async_import_statistics,
     STATISTICS_METADATA,
     DATA_SOURCE_CONFIG,
+    _create_statistic,
     _parse_date_to_timestamp,
     _apply_transformation,
     _compute_percentage,
@@ -144,4 +145,83 @@ def test_get_nested_value():
     assert _get_nested_value(data, "contributors.missing") is None
     assert _get_nested_value(data, "missing.nested") is None
 
+
+def test_statistics_metadata_state_class_alignment():
+    """Test that total/total_increasing sensors use sum statistics."""
+    sum_sensors = [
+        "total_sleep_duration",
+        "deep_sleep_duration",
+        "rem_sleep_duration",
+        "light_sleep_duration",
+        "awake_time",
+        "time_in_bed",
+        "steps",
+        "active_calories",
+        "total_calories",
+        "met_min_high",
+        "met_min_medium",
+        "met_min_low",
+        "stress_high_duration",
+        "recovery_high_duration",
+    ]
+    for sensor_key in sum_sensors:
+        assert STATISTICS_METADATA[sensor_key]["has_sum"] is True
+        assert STATISTICS_METADATA[sensor_key]["has_mean"] is False
+
+    mean_sensors = [
+        "sleep_score",
+        "sleep_efficiency",
+        "restfulness",
+        "sleep_timing",
+        "sleep_latency",
+        "deep_sleep_percentage",
+        "rem_sleep_percentage",
+        "readiness_score",
+        "temperature_deviation",
+        "resting_heart_rate",
+        "hrv_balance",
+        "activity_score",
+        "target_calories",
+        "average_sleep_hrv",
+        "lowest_sleep_heart_rate",
+        "average_sleep_heart_rate",
+        "average_heart_rate",
+        "min_heart_rate",
+        "max_heart_rate",
+        "spo2_average",
+        "breathing_disturbance_index",
+        "vo2_max",
+        "cardiovascular_age",
+        "sleep_recovery_score",
+        "daytime_recovery_score",
+        "stress_resilience_score",
+    ]
+    for sensor_key in mean_sensors:
+        assert STATISTICS_METADATA[sensor_key]["has_mean"] is True
+        assert STATISTICS_METADATA[sensor_key]["has_sum"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_statistic_builds_cumulative_sum(mock_hass, mock_config_entry):
+    """Test that has_sum sensors use sorted data points with cumulative sum."""
+    data_points = [
+        {"timestamp": datetime(2024, 1, 3, 12, 0, 0, tzinfo=timezone.utc), "value": 300},
+        {"timestamp": datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc), "value": 100},
+        {"timestamp": datetime(2024, 1, 2, 12, 0, 0, tzinfo=timezone.utc), "value": 200},
+    ]
+
+    with patch("custom_components.oura.statistics.er.async_get") as mock_er_get, \
+         patch("custom_components.oura.statistics.async_import_statistics_ha") as mock_import_ha:
+        mock_registry = MagicMock()
+        mock_er_get.return_value = mock_registry
+        mock_registry.async_get_entity_id.return_value = "sensor.oura_ring_steps"
+
+        await _create_statistic(mock_hass, "steps", data_points, mock_config_entry)
+
+    assert mock_import_ha.call_count == 1
+    _, metadata, statistics = mock_import_ha.call_args.args
+    assert metadata["statistic_id"] == "sensor.oura_ring_steps"
+    assert [point.start.day for point in statistics] == [1, 2, 3]
+    assert [point.state for point in statistics] == [100, 200, 300]
+    assert [point.sum for point in statistics] == [100, 300, 600]
 


### PR DESCRIPTION
## Summary

Fixes two related bugs:

1. **Sensors show yesterday's data instead of today's** (fixes #43)
   - `datetime.now().date()` uses server time (UTC on HA OS), not the user's configured timezone
   - Oura API v2 treats `end_date` as exclusive, so today's data was never fetched
   - Fix: use `ZoneInfo(hass.config.time_zone)` for local date, add +1 day to end_date

2. **Historical statistics charts are empty**
   - `STATISTICS_METADATA` had `has_mean=True` for duration sensors, but `const.py` declares them as `state_class: "total"` — HA's chart renderer expects `sum` statistics for these
   - `StatisticData.sum` was set to the daily value instead of a cumulative running total
   - Fix: align metadata with state_class, compute proper cumulative sums

## Changes

- `api.py`: Timezone-aware date calculation with exclusive end_date handling
- `statistics.py`: Align has_sum/has_mean with const.py state_class; build cumulative running sums
- `tests/test_statistics.py`: Added metadata alignment and cumulative sum tests
- `tests/test_api.py`: Added timezone date window test

## Test plan

- [ ] Verify sensors update to today's data after integration reload
- [ ] Verify historical charts show data in HA energy/history panels
- [ ] Verify sensors work correctly across timezone boundaries (DST transitions)
- [ ] Run `python -m compileall custom_components/oura` (syntax check passed)
- [ ] Run pytest with HA test fixtures (requires HA dev environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)