### PR TITLE
Release v2.5.2: timezone and historical statistics fixes

### DIFF
--- a/custom_components/oura/api.py
+++ b/custom_components/oura/api.py
@@ -5,6 +5,7 @@ import asyncio
 from datetime import datetime, timedelta
 import logging
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from aiohttp import ClientSession, ClientResponseError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -40,8 +41,10 @@ class OuraApiClient:
         Args:
             days_back: Number of days of historical data to fetch (default: 1)
         """
-        end_date = datetime.now().date()
-        start_date = end_date - timedelta(days=days_back)
+        local_tz = ZoneInfo(self.hass.config.time_zone)
+        today = datetime.now(tz=local_tz).date()
+        end_date = today + timedelta(days=1)  # Oura API end_date is exclusive
+        start_date = today - timedelta(days=days_back)
 
         sleep_data, readiness_data, activity_data, heartrate_data, sleep_detail_data, stress_data, resilience_data, spo2_data, vo2_max_data, cardiovascular_age_data, sleep_time_data = await asyncio.gather(
             self._async_get_sleep(start_date, end_date),

--- a/custom_components/oura/manifest.json
+++ b/custom_components/oura/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/louispires/oura-v2-custom-component/issues",
   "requirements": [],
-  "version": "2.5.1"
+  "version": "2.5.2"
 }

--- a/custom_components/oura/statistics.py
+++ b/custom_components/oura/statistics.py
@@ -60,13 +60,13 @@ STATISTICS_METADATA = {
     "sleep_efficiency": {"name": "Sleep Efficiency", "unit": "%", "has_mean": True, "has_sum": False},
     "restfulness": {"name": "Restfulness", "unit": "%", "has_mean": True, "has_sum": False},
     "sleep_timing": {"name": "Sleep Timing", "unit": None, "has_mean": True, "has_sum": False},
-    "total_sleep_duration": {"name": "Total Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
-    "deep_sleep_duration": {"name": "Deep Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
-    "rem_sleep_duration": {"name": "REM Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
-    "light_sleep_duration": {"name": "Light Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
-    "awake_time": {"name": "Awake Time", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
+    "total_sleep_duration": {"name": "Total Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
+    "deep_sleep_duration": {"name": "Deep Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
+    "rem_sleep_duration": {"name": "REM Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
+    "light_sleep_duration": {"name": "Light Sleep Duration", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
+    "awake_time": {"name": "Awake Time", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
     "sleep_latency": {"name": "Sleep Latency", "unit": UnitOfTime.MINUTES, "has_mean": True, "has_sum": False},
-    "time_in_bed": {"name": "Time in Bed", "unit": UnitOfTime.HOURS, "has_mean": True, "has_sum": False},
+    "time_in_bed": {"name": "Time in Bed", "unit": UnitOfTime.HOURS, "has_mean": False, "has_sum": True},
     "bedtime_start": {"name": "Bedtime Start", "unit": None, "has_mean": False, "has_sum": False},
     "bedtime_end": {"name": "Bedtime End", "unit": None, "has_mean": False, "has_sum": False},
     "deep_sleep_percentage": {"name": "Deep Sleep Percentage", "unit": "%", "has_mean": True, "has_sum": False},
@@ -89,8 +89,8 @@ STATISTICS_METADATA = {
     "average_heart_rate": {"name": "Average Heart Rate", "unit": "bpm", "has_mean": True, "has_sum": False},
     "min_heart_rate": {"name": "Minimum Heart Rate", "unit": "bpm", "has_mean": True, "has_sum": False},
     "max_heart_rate": {"name": "Maximum Heart Rate", "unit": "bpm", "has_mean": True, "has_sum": False},
-    "stress_high_duration": {"name": "Stress High Duration", "unit": UnitOfTime.MINUTES, "has_mean": True, "has_sum": False},
-    "recovery_high_duration": {"name": "Recovery High Duration", "unit": UnitOfTime.MINUTES, "has_mean": True, "has_sum": False},
+    "stress_high_duration": {"name": "Stress High Duration", "unit": UnitOfTime.MINUTES, "has_mean": False, "has_sum": True},
+    "recovery_high_duration": {"name": "Recovery High Duration", "unit": UnitOfTime.MINUTES, "has_mean": False, "has_sum": True},
     "stress_day_summary": {"name": "Stress Day Summary", "unit": None, "has_mean": False, "has_sum": False},
     "resilience_level": {"name": "Resilience Level", "unit": None, "has_mean": False, "has_sum": False},
     "sleep_recovery_score": {"name": "Sleep Recovery Score", "unit": None, "has_mean": True, "has_sum": False},
@@ -431,11 +431,17 @@ async def _create_statistic(
 
     # Create data points
     statistics = []
-    for point in data_points:
+    sorted_data_points = sorted(data_points, key=lambda point: point["timestamp"])
+    running_sum = 0.0
+    for point in sorted_data_points:
+        value = point["value"]
+        if metadata["has_sum"]:
+            running_sum += value
         stat_data = StatisticData(
             start=point["timestamp"],
-            mean=point["value"] if metadata["has_mean"] else None,
-            sum=point["value"] if metadata["has_sum"] else None,
+            state=value if metadata["has_sum"] else None,
+            mean=value if metadata["has_mean"] else None,
+            sum=running_sum if metadata["has_sum"] else None,
         )
         statistics.append(stat_data)
 

--- a/custom_components/oura/statistics.py
+++ b/custom_components/oura/statistics.py
@@ -165,22 +165,22 @@ DATA_SOURCE_CONFIG = {
     },
     "stress": {
         "mappings": [
-            {"sensor_key": "stress_high_duration", "api_path": "stress_high_duration"},
-            {"sensor_key": "recovery_high_duration", "api_path": "recovery_high_duration"},
+            {"sensor_key": "stress_high_duration", "api_path": "stress_high", "transform": "seconds_to_minutes"},
+            {"sensor_key": "recovery_high_duration", "api_path": "recovery_high", "transform": "seconds_to_minutes"},
             {"sensor_key": "stress_day_summary", "api_path": "day_summary"},
         ],
     },
     "resilience": {
         "mappings": [
             {"sensor_key": "resilience_level", "api_path": "level"},
-            {"sensor_key": "sleep_recovery_score", "api_path": "sleep_recovery_score"},
-            {"sensor_key": "daytime_recovery_score", "api_path": "daytime_recovery_score"},
-            {"sensor_key": "stress_resilience_score", "api_path": "contributors.activity_score"},
+            {"sensor_key": "sleep_recovery_score", "api_path": "contributors.sleep_recovery"},
+            {"sensor_key": "daytime_recovery_score", "api_path": "contributors.daytime_recovery"},
+            {"sensor_key": "stress_resilience_score", "api_path": "contributors.stress"},
         ],
     },
     "spo2": {
         "mappings": [
-            {"sensor_key": "spo2_average", "api_path": "average"},
+            {"sensor_key": "spo2_average", "api_path": "spo2_percentage.average"},
             {"sensor_key": "breathing_disturbance_index", "api_path": "breathing_disturbance_index"},
         ],
     },

--- a/custom_components/oura/statistics.py
+++ b/custom_components/oura/statistics.py
@@ -78,6 +78,7 @@ STATISTICS_METADATA = {
     "temperature_deviation": {"name": "Temperature Deviation", "unit": UnitOfTemperature.CELSIUS, "has_mean": True, "has_sum": False},
     "resting_heart_rate": {"name": "Resting Heart Rate Score", "unit": None, "has_mean": True, "has_sum": False},
     "hrv_balance": {"name": "HRV Balance Score", "unit": None, "has_mean": True, "has_sum": False},
+    "sleep_regularity": {"name": "Sleep Regularity Score", "unit": None, "has_mean": True, "has_sum": False},
     "activity_score": {"name": "Activity Score", "unit": None, "has_mean": True, "has_sum": False},
     "steps": {"name": "Steps", "unit": "steps", "has_mean": False, "has_sum": True},
     "active_calories": {"name": "Active Calories", "unit": UnitOfEnergy.KILO_CALORIE, "has_mean": False, "has_sum": True},
@@ -146,6 +147,7 @@ DATA_SOURCE_CONFIG = {
             {"sensor_key": "temperature_deviation", "api_path": "temperature_deviation"},
             {"sensor_key": "resting_heart_rate", "api_path": "contributors.resting_heart_rate"},
             {"sensor_key": "hrv_balance", "api_path": "contributors.hrv_balance"},
+            {"sensor_key": "sleep_regularity", "api_path": "contributors.sleep_regularity"},
         ],
     },
     "activity": {
@@ -191,15 +193,12 @@ DATA_SOURCE_CONFIG = {
     },
     "cardiovascular_age": {
         "mappings": [
-            {"sensor_key": "cardiovascular_age", "api_path": "age"},
+            {"sensor_key": "cardiovascular_age", "api_path": "vascular_age"},
         ],
     },
-    "sleep_time": {
-        "mappings": [
-            {"sensor_key": "optimal_bedtime_start", "api_path": "optimal_bedtime_start"},
-            {"sensor_key": "optimal_bedtime_end", "api_path": "optimal_bedtime_end"},
-        ],
-    },
+    # sleep_time (optimal_bedtime_start/end) intentionally excluded from backfill:
+    # API returns second-offsets-from-midnight + timezone, requiring complex transform
+    # that the generic processor can't handle. Live data handled by coordinator.
 }
 
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,4 +1,40 @@
-﻿# 🎉 Oura Ring v2 Integration v2.5.1 - Data Verification & Sleep Regularity
+﻿# 🎉 Oura Ring v2 Integration v2.5.2 - Timezone & Historical Statistics Fixes
+
+This release combines PR #45 and PR #47 into a single patch release focused on correct current-day data and reliable historical statistics backfill - Thank you @issmirnov
+
+## 🐛 FIXES IN v2.5.2
+
+### Sensors now show today's data in the configured Home Assistant timezone
+
+- **Timezone-aware date window**: Daily fetches now use `hass.config.time_zone` instead of server-local UTC time
+- **Exclusive end_date fix**: API requests now include `today + 1 day` so Oura's exclusive `end_date` behavior does not drop the current day
+- **User impact**: Daily sensors no longer lag by one day on Home Assistant OS and other UTC-hosted installs
+
+### Historical statistics charts render correctly
+
+- **Metadata alignment**: Duration and cumulative sensors now publish `sum` statistics instead of `mean` when their entity `state_class` is `total` or `total_increasing`
+- **Cumulative totals**: Imported `StatisticData.sum` values are now emitted as running totals instead of isolated daily values
+- **User impact**: Home Assistant history and statistics charts can render these backfilled sensors correctly
+
+### Historical backfill uses corrected Oura API paths
+
+- **Resilience backfill**: Fixed `sleep_recovery_score`, `daytime_recovery_score`, and `stress_resilience_score` paths
+- **Stress backfill**: Fixed stress and recovery duration keys and converted them from seconds to minutes during import
+- **SpO2 backfill**: Fixed `spo2_average` to use the nested `spo2_percentage.average` field
+- **Readiness backfill**: Added `sleep_regularity` historical import support
+- **Cardiovascular Age**: Corrected the backfill field to use `vascular_age`
+- **Sleep Time backfill**: Removed broken `sleep_time` backfill from the generic importer because it requires a dedicated transform that live data already handles correctly
+
+## 🧪 TESTING & VALIDATION
+
+- ✅ 53 automated tests passing in the Home Assistant Docker test environment
+- ✅ Added timezone-aware date window coverage
+- ✅ Added statistics metadata alignment coverage
+- ✅ Added cumulative sum coverage for imported statistics
+
+---
+
+# 🎉 Oura Ring v2 Integration v2.5.1 - Data Verification & Sleep Regularity
 
 This release adds data verification attributes and a new Sleep Regularity sensor from the latest Oura API update.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,53 @@
+"""Tests for Oura API client date window handling."""
+from datetime import date, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.oura.api import OuraApiClient
+
+
+class _FrozenDateTime(datetime):
+    """Frozen datetime for deterministic timezone-aware date calculations."""
+
+    @classmethod
+    def now(cls, tz=None):
+        """Return a fixed local time and require timezone-aware calls."""
+        assert tz is not None
+        return cls(2026, 3, 23, 1, 30, tzinfo=tz)
+
+
+@pytest.mark.asyncio
+async def test_async_get_data_uses_local_date_and_exclusive_end_date():
+    """Test timezone-aware date range and +1 day exclusive end date handling."""
+    hass = MagicMock()
+    hass.config.time_zone = "America/Denver"
+    session = MagicMock()
+    entry = MagicMock()
+    client = OuraApiClient(hass, session, entry)
+
+    endpoint_methods = [
+        "_async_get_sleep",
+        "_async_get_readiness",
+        "_async_get_activity",
+        "_async_get_heartrate",
+        "_async_get_sleep_detail",
+        "_async_get_stress",
+        "_async_get_resilience",
+        "_async_get_spo2",
+        "_async_get_vo2_max",
+        "_async_get_cardiovascular_age",
+        "_async_get_sleep_time",
+    ]
+    for method_name in endpoint_methods:
+        setattr(client, method_name, AsyncMock(return_value={"data": []}))
+
+    with patch("custom_components.oura.api.datetime", _FrozenDateTime):
+        await client.async_get_data(days_back=1)
+
+    expected_start = date(2026, 3, 22)
+    expected_end = date(2026, 3, 24)
+    for method_name in endpoint_methods:
+        mocked_method = getattr(client, method_name)
+        assert mocked_method.await_count == 1
+        assert mocked_method.await_args.args == (expected_start, expected_end)

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -8,6 +8,7 @@ from custom_components.oura.statistics import (
     async_import_statistics,
     STATISTICS_METADATA,
     DATA_SOURCE_CONFIG,
+    _create_statistic,
     _parse_date_to_timestamp,
     _apply_transformation,
     _compute_percentage,
@@ -144,4 +145,83 @@ def test_get_nested_value():
     assert _get_nested_value(data, "contributors.missing") is None
     assert _get_nested_value(data, "missing.nested") is None
 
+
+def test_statistics_metadata_state_class_alignment():
+    """Test that total/total_increasing sensors use sum statistics."""
+    sum_sensors = [
+        "total_sleep_duration",
+        "deep_sleep_duration",
+        "rem_sleep_duration",
+        "light_sleep_duration",
+        "awake_time",
+        "time_in_bed",
+        "steps",
+        "active_calories",
+        "total_calories",
+        "met_min_high",
+        "met_min_medium",
+        "met_min_low",
+        "stress_high_duration",
+        "recovery_high_duration",
+    ]
+    for sensor_key in sum_sensors:
+        assert STATISTICS_METADATA[sensor_key]["has_sum"] is True
+        assert STATISTICS_METADATA[sensor_key]["has_mean"] is False
+
+    mean_sensors = [
+        "sleep_score",
+        "sleep_efficiency",
+        "restfulness",
+        "sleep_timing",
+        "sleep_latency",
+        "deep_sleep_percentage",
+        "rem_sleep_percentage",
+        "readiness_score",
+        "temperature_deviation",
+        "resting_heart_rate",
+        "hrv_balance",
+        "activity_score",
+        "target_calories",
+        "average_sleep_hrv",
+        "lowest_sleep_heart_rate",
+        "average_sleep_heart_rate",
+        "average_heart_rate",
+        "min_heart_rate",
+        "max_heart_rate",
+        "spo2_average",
+        "breathing_disturbance_index",
+        "vo2_max",
+        "cardiovascular_age",
+        "sleep_recovery_score",
+        "daytime_recovery_score",
+        "stress_resilience_score",
+    ]
+    for sensor_key in mean_sensors:
+        assert STATISTICS_METADATA[sensor_key]["has_mean"] is True
+        assert STATISTICS_METADATA[sensor_key]["has_sum"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_statistic_builds_cumulative_sum(mock_hass, mock_config_entry):
+    """Test that has_sum sensors use sorted data points with cumulative sum."""
+    data_points = [
+        {"timestamp": datetime(2024, 1, 3, 12, 0, 0, tzinfo=timezone.utc), "value": 300},
+        {"timestamp": datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc), "value": 100},
+        {"timestamp": datetime(2024, 1, 2, 12, 0, 0, tzinfo=timezone.utc), "value": 200},
+    ]
+
+    with patch("custom_components.oura.statistics.er.async_get") as mock_er_get, \
+         patch("custom_components.oura.statistics.async_import_statistics_ha") as mock_import_ha:
+        mock_registry = MagicMock()
+        mock_er_get.return_value = mock_registry
+        mock_registry.async_get_entity_id.return_value = "sensor.oura_ring_steps"
+
+        await _create_statistic(mock_hass, "steps", data_points, mock_config_entry)
+
+    assert mock_import_ha.call_count == 1
+    _, metadata, statistics = mock_import_ha.call_args.args
+    assert metadata["statistic_id"] == "sensor.oura_ring_steps"
+    assert [point.start.day for point in statistics] == [1, 2, 3]
+    assert [point.state for point in statistics] == [100, 200, 300]
+    assert [point.sum for point in statistics] == [100, 300, 600]
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -221,7 +221,7 @@ async def test_create_statistic_builds_cumulative_sum(mock_hass, mock_config_ent
     assert mock_import_ha.call_count == 1
     _, metadata, statistics = mock_import_ha.call_args.args
     assert metadata["statistic_id"] == "sensor.oura_ring_steps"
-    assert [point.start.day for point in statistics] == [1, 2, 3]
-    assert [point.state for point in statistics] == [100, 200, 300]
-    assert [point.sum for point in statistics] == [100, 300, 600]
+    assert [point["start"].day for point in statistics] == [1, 2, 3]
+    assert [point["state"] for point in statistics] == [100, 200, 300]
+    assert [point["sum"] for point in statistics] == [100, 300, 600]
 


### PR DESCRIPTION
This PR combines the changes from #45 and #47 and prepares the v2.5.2 release.\n\nIncluded changes:\n- Fix timezone-aware daily fetch windows so sensors show the correct current day\n- Fix long-term statistics metadata and cumulative sums so charts render correctly\n- Fix historical backfill API paths for resilience, stress, SpO2, readiness sleep regularity, and cardiovascular age\n- Update release notes and bump the integration version to 2.5.2\n\nValidation:\n- 53 tests passed in the Home Assistant Docker test environment