### PR TITLE
fix: Show the most recently set up ring in device info

### DIFF
--- a/custom_components/oura/coordinator.py
+++ b/custom_components/oura/coordinator.py
@@ -156,7 +156,10 @@ class OuraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return None
 
         try:
-            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                return parsed.replace(tzinfo=UTC)
+            return parsed.astimezone(UTC)
         except (ValueError, AttributeError):
             return None
 

--- a/custom_components/oura/coordinator.py
+++ b/custom_components/oura/coordinator.py
@@ -1,7 +1,7 @@
 """DataUpdateCoordinator for Oura Ring."""
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 import logging
 from typing import Any
 
@@ -599,7 +599,13 @@ class OuraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Process ring configuration for device info enrichment."""
         if ring_config_data := data.get("ring_configuration", {}).get("data"):
             if ring_config_data and len(ring_config_data) > 0:
-                config = ring_config_data[0]
+                # Oura retains configurations for previously set up rings, so choose
+                # the newest setup instead of relying on response order.
+                config = max(
+                    ring_config_data,
+                    key=lambda item: self._parse_iso_datetime(item.get("set_up_at"))
+                    or datetime.min.replace(tzinfo=UTC),
+                )
                 processed["ring_hardware_type"] = config.get("hardware_type")
                 processed["ring_firmware_version"] = config.get("firmware_version")
                 processed["ring_color"] = config.get("color")

--- a/tests/test_ring_battery.py
+++ b/tests/test_ring_battery.py
@@ -212,6 +212,61 @@ class TestProcessRingConfiguration:
 
         assert processed["ring_hardware_type"] == "gen4"
 
+    def test_naive_timestamp_beats_missing_timestamp(self):
+        """Naive setup timestamps are handled safely and preferred over missing values."""
+        coordinator = OuraDataUpdateCoordinator.__new__(OuraDataUpdateCoordinator)
+        data = {
+            "ring_configuration": {
+                "data": [
+                    {
+                        "id": "ring-1",
+                        "hardware_type": "gen4",
+                        "firmware_version": "2.8.10",
+                        "set_up_at": "2026-07-08T00:00:00",
+                    },
+                    {
+                        "id": "ring-2",
+                        "hardware_type": "gen3",
+                        "firmware_version": "2.1.3",
+                    },
+                ]
+            }
+        }
+        processed = {}
+
+        coordinator._process_ring_configuration(data, processed)
+
+        assert processed["ring_hardware_type"] == "gen4"
+        assert processed["ring_firmware_version"] == "2.8.10"
+
+    def test_invalid_timestamp_falls_back_without_crashing(self):
+        """Malformed setup timestamps are ignored instead of breaking selection."""
+        coordinator = OuraDataUpdateCoordinator.__new__(OuraDataUpdateCoordinator)
+        data = {
+            "ring_configuration": {
+                "data": [
+                    {
+                        "id": "ring-1",
+                        "hardware_type": "gen3",
+                        "firmware_version": "2.1.3",
+                        "set_up_at": "not-a-datetime",
+                    },
+                    {
+                        "id": "ring-2",
+                        "hardware_type": "gen4",
+                        "firmware_version": "2.8.10",
+                        "set_up_at": "2026-07-08T00:00:00.000Z",
+                    },
+                ]
+            }
+        }
+        processed = {}
+
+        coordinator._process_ring_configuration(data, processed)
+
+        assert processed["ring_hardware_type"] == "gen4"
+        assert processed["ring_firmware_version"] == "2.8.10"
+
 
 # ---------------------------------------------------------------------------
 # API client: ring_battery_level endpoint

--- a/tests/test_ring_battery.py
+++ b/tests/test_ring_battery.py
@@ -169,14 +169,41 @@ class TestProcessRingConfiguration:
 
         assert "ring_hardware_type" not in processed
 
-    def test_first_config_used_for_multiple_rings(self):
-        """First ring configuration entry is used when multiple exist."""
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_most_recent_config_used_for_multiple_rings(self, reverse: bool):
+        """Most recently set up ring is used regardless of response order."""
+        coordinator = OuraDataUpdateCoordinator.__new__(OuraDataUpdateCoordinator)
+        ring_configs = [
+            {
+                "id": "ring-1",
+                "hardware_type": "gen4",
+                "firmware_version": "2.8.10",
+                "set_up_at": "2025-12-21T00:00:00.000Z",
+            },
+            {
+                "id": "ring-2",
+                "hardware_type": "or5",
+                "firmware_version": "2.1.3",
+                "set_up_at": "2026-07-08T00:00:00.000Z",
+            },
+        ]
+        if reverse:
+            ring_configs.reverse()
+        data = {"ring_configuration": {"data": ring_configs}}
+        processed = {}
+        coordinator._process_ring_configuration(data, processed)
+
+        assert processed["ring_hardware_type"] == "or5"
+        assert processed["ring_firmware_version"] == "2.1.3"
+
+    def test_first_config_used_when_setup_timestamps_missing(self):
+        """First ring remains the fallback when setup timestamps are unavailable."""
         coordinator = OuraDataUpdateCoordinator.__new__(OuraDataUpdateCoordinator)
         data = {
             "ring_configuration": {
                 "data": [
-                    {"id": "ring-1", "hardware_type": "gen4", "firmware_version": "2.8.10"},
-                    {"id": "ring-2", "hardware_type": "gen3", "firmware_version": "1.5.0"},
+                    {"id": "ring-1", "hardware_type": "gen4"},
+                    {"id": "ring-2", "hardware_type": "gen3"},
                 ]
             }
         }
@@ -331,11 +358,22 @@ class TestDeviceInfoEnrichment:
         sensor._sensor_type = sensor_type
         return sensor
 
-    def test_model_uses_hardware_type(self):
+    @pytest.mark.parametrize(
+        ("hardware_type", "expected_model"),
+        [("gen4", "Oura Ring 4"), ("or5", "Oura Ring 5")],
+    )
+    def test_model_uses_hardware_type(
+        self, hardware_type: str, expected_model: str
+    ):
         """device_info model maps hardware_type to a display name."""
-        sensor = self._make_sensor_entity({"ring_hardware_type": "gen4", "ring_firmware_version": "2.8.10"})
+        sensor = self._make_sensor_entity(
+            {
+                "ring_hardware_type": hardware_type,
+                "ring_firmware_version": "2.8.10",
+            }
+        )
         info = sensor.device_info
-        assert info["model"] == "Oura Ring 4"
+        assert info["model"] == expected_model
 
     def test_sw_version_uses_firmware_version(self):
         """device_info sw_version is set from ring firmware_version."""


### PR DESCRIPTION
Hey, thanks for all the work on this integration. It's been great having Oura data in Home Assistant to mess around with. :)

Here's a small fix for something I stumbled on. Oura keeps configuration records for previously paired rings. I hit this after upgrading from Ring 4 to Ring 5: the API returned both configurations with the older ring first, and Home Assistant kept showing the Ring 4 model and firmware because the coordinator always selected `data[0]`.

This picks the configuration with the newest `set_up_at` timestamp instead, while retaining the first record as a fallback when Oura omits timestamps.
